### PR TITLE
Update SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,50 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+This project is under active development, and we provide security updates for the latest version only. Please ensure you're using the latest version of the project to receive security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| latest  | :white_check_mark: |
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+We take the security of the lambda-in-private-vpc project seriously. If you have found a potential security vulnerability, we kindly ask you to report it privately, so that we can assess and address the issue before it becomes publicly known.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+### What Constitutes a Vulnerability
+
+A vulnerability is a weakness or flaw in the project that can be exploited to compromise the security, integrity, or availability of the system or its data. Examples of vulnerabilities include, but are not limited to:
+
+- Unauthenticated access to sensitive data
+- Injection attacks (e.g., SQL injection, cross-site scripting)
+- Insecure defaults or configurations
+- Insufficient access controls
+- Remote code execution
+
+### How to Privately Report a Vulnerability using GitHub
+
+Please follow these steps to privately report a security vulnerability:
+
+1. On GitHub.com, navigate to the main page of the [lambda-in-private-vpc repository](https://github.com/Hack23/lambda-in-private-vpc).
+2. Under the repository name, click **Security**. If you cannot see the "Security" tab, select the dropdown menu, and then click **Security**.
+3. In the left sidebar, under "Reporting", click **Advisories**.
+4. Click **Report a vulnerability** to open the advisory form.
+5. Fill in the advisory details form. Provide as much information as possible to help us understand and reproduce the issue.
+6. At the bottom of the form, click **Submit report**.
+
+After you submit the report, the maintainers of the lambda-in-private-vpc repository will be notified. They will review the report, validate the vulnerability, and take necessary actions to address the issue. You will be added as a collaborator and credited for the security advisory.
+
+### Disclosure Timeline
+
+Upon receipt of a vulnerability report, our team will:
+
+1. Acknowledge the report within 48 hours
+2. Validate the vulnerability within 7 days
+3. Develop and release a patch or mitigation within 30 days, depending on the complexity and severity of the issue
+4. Publish a security advisory with a detailed description of the vulnerability and the fix
+
+### Recognition and Anonymity
+
+We appreciate your effort in helping us maintain a secure and reliable project. If your report results in a confirmed security fix, we will recognize your contribution in the release notes and/or a public acknowledgment, unless you request to remain anonymous.
+
+Thank you for helping us keep the lambda-in-private-vpc project and its users safe.


### PR DESCRIPTION
Updated with instructions on how to privately report a security vulnerability using GitHub. This SECURITY.md file now contains instructions on how to privately report a security vulnerability using GitHub's security advisory feature, instead of using an email address.

By submitting a request, you represent that you have the right to license
your contribution to the community, and agree that your contributions are
licensed under the [The Apache Software License, Version 2.0](LICENSE.md).
