### PR TITLE
Update template.yml

### DIFF
--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -597,6 +597,12 @@ Resources:
         IntegrationHttpMethod: POST
         IntegrationResponses:
           - StatusCode: 200
+            ResponseTemplates:
+              application/json: ""
+            ResponseParameters:
+              method.response.header.Strict-Transport-Security: "'max-age=31536000; includeSubDomains'"
+              method.response.header.X-Content-Type-Options: "'nosniff'"
+              method.response.header.Cache-Control: "'no-store, no-cache, must-revalidate, private'"
         Type: AWS
         Uri: !Sub 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Lambda.Arn}/invocations'
 #      RequestValidatorId: !Ref ApiRequestValidator


### PR DESCRIPTION
resolve some issues in https://github.com/Hack23/lambda-in-private-vpc/issues/61 To address the findings from the ZAP API Scan, you can update your API Gateway settings as follows:

Strict-Transport-Security Header Not Set [10035]:
Add the Strict-Transport-Security header to your API Gateway integration response settings:

yaml
Copy code
IntegrationResponse:
  - StatusCode: '200' ResponseTemplates: application/json: "" ResponseParameters: method.response.header.Strict-Transport-Security: "'max-age=31536000; includeSubDomains'" X-Content-Type-Options Header Missing [10021]:
Add the X-Content-Type-Options header to your API Gateway integration response settings:

yaml
Copy code
IntegrationResponse:
  - StatusCode: '200' ResponseTemplates: application/json: "" ResponseParameters: method.response.header.X-Content-Type-Options: "'nosniff'" A Client Error response code was returned by the server [100000]: This error could be due to many reasons, such as incorrect resource paths, improper handling of errors, or missing authentication. You should review your API implementation and ensure that appropriate error handling is in place.

Re-examine Cache-control Directives [10015]:
Update your API Gateway integration response settings to include the appropriate Cache-Control header:

yaml
Copy code
IntegrationResponse:
  - StatusCode: '200' ResponseTemplates: application/json: "" ResponseParameters: method.response.header.Cache-Control: "'no-store, no-cache, must-revalidate, private'" Storable and Cacheable Content [10049]:
This finding may require a review of your caching strategy. If you need to prevent caching, you can set the Cache-Control header as shown in step 4.

After making the necessary changes, you can re-run the ZAP API Scan to validate if the issues have been resolved.

By submitting a request, you represent that you have the right to license
your contribution to the community, and agree that your contributions are
licensed under the [The Apache Software License, Version 2.0](LICENSE.md).
